### PR TITLE
fix typo in linuxudp.h

### DIFF
--- a/xwords4/linux/linuxudp.h
+++ b/xwords4/linux/linuxudp.h
@@ -17,7 +17,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 #ifndef _LINUXUDP_H_
-#define _LINUXUD_H_
+#define _LINUXUDP_H_
 
 #ifdef XWFEATURE_IP_DIRECT
 


### PR DESCRIPTION
Compilation failed for me with 
``` shell
Dans le fichier inclus depuis cursesmain.c:66:
linuxudp.h:19: erreur: le garde-fou de l'en-tête « _LINUXUDP_H_ » est suivi par « #define » d'une macro différente [-Werror=header-guard]
   19 | #ifndef _LINUXUDP_H_
linuxudp.h:20: note: « _LINUXUD_H_ » est défini ici ; vouliez-vous utiliser « _LINUXUDP_H_ » ?
   20 | #define _LINUXUD_H_
cc1 : tous les avertissements sont traités comme des erreurs
make: *** [../common/rules.mk:30: obj_linux_rel/cursesmain.o] Error 1
```